### PR TITLE
[feature] 결제 성공/실패 API, 공통모듈 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,8 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.trustamarket.paymentservice'
+group = 'com.trusta-market'
 version = '0.0.1-SNAPSHOT'
-description = 'payment-service'
 
 java {
     toolchain {
@@ -16,6 +15,13 @@ java {
 
 repositories {
     mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.github.com/trusta-market/common")
+        credentials {
+            username = project.findProperty("gpr.user")?.toString() ?: System.getenv("GPR_USER")
+            password = project.findProperty("gpr.token")?.toString() ?: System.getenv("GPR_TOKEN")
+        }
+    }
 }
 
 ext {
@@ -23,6 +29,8 @@ ext {
 }
 
 dependencies {
+    implementation 'com.trustamarket:common:0.0.1-SNAPSHOT'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/build.gradle
+++ b/build.gradle
@@ -53,3 +53,7 @@ dependencyManagement {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+tasks.withType(Test).configureEach {
+    jvmArgs '-XX:+EnableDynamicAgentLoading'
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/command/CreatePaymentCommand.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/command/CreatePaymentCommand.java
@@ -1,5 +1,8 @@
 package com.trustamarket.paymentservice.paymentservice.application.dto.command;
 
+import java.util.UUID;
+
 public record CreatePaymentCommand (
-    long amount
+        UUID chargeId,
+        long amount
 ){}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/command/FailPaymentCommand.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/command/FailPaymentCommand.java
@@ -1,0 +1,9 @@
+package com.trustamarket.paymentservice.paymentservice.application.dto.command;
+
+import java.util.UUID;
+
+public record FailPaymentCommand (
+        UUID paymentId,
+        String code,
+        String message
+) {}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/command/SucceededPaymentCommand.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/command/SucceededPaymentCommand.java
@@ -1,0 +1,9 @@
+package com.trustamarket.paymentservice.paymentservice.application.dto.command;
+
+import java.util.UUID;
+
+public record SucceededPaymentCommand(
+        UUID paymentId,
+        String paymentKey,
+        long amount
+){}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/CreatePaymentResult.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/CreatePaymentResult.java
@@ -1,5 +1,6 @@
 package com.trustamarket.paymentservice.paymentservice.application.dto.result;
 
+import com.trustamarket.paymentservice.paymentservice.domain.entity.Payment;
 import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
 
 import java.time.Instant;
@@ -11,4 +12,14 @@ public record CreatePaymentResult (
     PaymentStatus paymentStatus,
     long amount,
     Instant createdAt
-){}
+){
+    public static CreatePaymentResult from(Payment payment) {
+        return new CreatePaymentResult(
+                payment.getPaymentId(),
+                payment.getChargeId(),
+                payment.getPaymentStatus(),
+                payment.getAmount(),
+                payment.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/CreatePaymentResult.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/CreatePaymentResult.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 
 public record CreatePaymentResult (
     UUID paymentId,
+    UUID chargeId,
     PaymentStatus paymentStatus,
     long amount,
     Instant createdAt

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/FailPaymentResult.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/FailPaymentResult.java
@@ -1,0 +1,12 @@
+package com.trustamarket.paymentservice.paymentservice.application.dto.result;
+
+import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record FailPaymentResult (
+    UUID paymentId,
+    PaymentStatus paymentStatus,
+    Instant updatedAt
+){}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/FailPaymentResult.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/FailPaymentResult.java
@@ -1,12 +1,21 @@
 package com.trustamarket.paymentservice.paymentservice.application.dto.result;
 
+import com.trustamarket.paymentservice.paymentservice.domain.entity.Payment;
 import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
 
 import java.time.Instant;
 import java.util.UUID;
 
 public record FailPaymentResult (
-    UUID paymentId,
-    PaymentStatus paymentStatus,
-    Instant updatedAt
-){}
+        UUID paymentId,
+        PaymentStatus paymentStatus,
+        Instant updatedAt
+) {
+    public static FailPaymentResult from(Payment payment) {
+        return new FailPaymentResult(
+                payment.getPaymentId(),
+                payment.getPaymentStatus(),
+                payment.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/SucceededPaymentResult.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/SucceededPaymentResult.java
@@ -16,6 +16,7 @@ public record SucceededPaymentResult(
         return new SucceededPaymentResult(
                 payment.getPaymentId(),
                 payment.getPaymentStatus(),
+                payment.getAmount(),
                 payment.getUpdatedAt()
         );
     }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/SucceededPaymentResult.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/SucceededPaymentResult.java
@@ -1,0 +1,13 @@
+package com.trustamarket.paymentservice.paymentservice.application.dto.result;
+
+import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record SucceededPaymentResult(
+        UUID paymentId,
+        PaymentStatus paymentStatus,
+        long amount,
+        Instant updatedAt
+){}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/SucceededPaymentResult.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/dto/result/SucceededPaymentResult.java
@@ -1,5 +1,6 @@
 package com.trustamarket.paymentservice.paymentservice.application.dto.result;
 
+import com.trustamarket.paymentservice.paymentservice.domain.entity.Payment;
 import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
 
 import java.time.Instant;
@@ -10,4 +11,12 @@ public record SucceededPaymentResult(
         PaymentStatus paymentStatus,
         long amount,
         Instant updatedAt
-){}
+){
+    public static SucceededPaymentResult from(Payment payment) {
+        return new SucceededPaymentResult(
+                payment.getPaymentId(),
+                payment.getPaymentStatus(),
+                payment.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/port/PaymentUseCase.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/port/PaymentUseCase.java
@@ -1,8 +1,14 @@
 package com.trustamarket.paymentservice.paymentservice.application.port;
 
 import com.trustamarket.paymentservice.paymentservice.application.dto.command.CreatePaymentCommand;
+import com.trustamarket.paymentservice.paymentservice.application.dto.command.FailPaymentCommand;
+import com.trustamarket.paymentservice.paymentservice.application.dto.command.SucceededPaymentCommand;
 import com.trustamarket.paymentservice.paymentservice.application.dto.result.CreatePaymentResult;
+import com.trustamarket.paymentservice.paymentservice.application.dto.result.FailPaymentResult;
+import com.trustamarket.paymentservice.paymentservice.application.dto.result.SucceededPaymentResult;
 
 public interface PaymentUseCase {
     CreatePaymentResult createPayment(CreatePaymentCommand command);
+    SucceededPaymentResult succeededPayment(SucceededPaymentCommand command);
+    FailPaymentResult failPayment(FailPaymentCommand command);
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
@@ -28,7 +28,7 @@ public class PaymentService implements PaymentUseCase {
     public CreatePaymentResult createPayment(CreatePaymentCommand command) {
         try{
             Payment payment = Payment.create(command.chargeId(), Amount.of(command.amount()));
-            Payment savedPayment = paymentRepository.saveandFlush(payment);
+            Payment savedPayment = paymentRepository.saveAndFlush(payment);
 
             return new CreatePaymentResult(
                     savedPayment.getPaymentId(),

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
@@ -30,13 +30,8 @@ public class PaymentService implements PaymentUseCase {
             Payment payment = Payment.create(command.chargeId(), Amount.of(command.amount()));
             Payment savedPayment = paymentRepository.saveAndFlush(payment);
 
-            return new CreatePaymentResult(
-                    savedPayment.getPaymentId(),
-                    savedPayment.getChargeId(),
-                    savedPayment.getPaymentStatus(),
-                    savedPayment.getAmount(),
-                    savedPayment.getCreatedAt()
-            );
+            CreatePaymentResult result = CreatePaymentResult.from(savedPayment);
+            return result;
 
         }catch (DataIntegrityViolationException e){
             throw new PaymentException(PaymentErrorCode.DUPLICATE_CHARGE_ID);
@@ -50,12 +45,8 @@ public class PaymentService implements PaymentUseCase {
 
         payment.successPayment(command.paymentKey(), command.amount());
 
-        return new SucceededPaymentResult(
-                payment.getPaymentId(),
-                payment.getPaymentStatus(),
-                payment.getAmount(),
-                payment.getUpdatedAt()
-        );
+        SucceededPaymentResult result = SucceededPaymentResult.from(payment);
+        return result;
     }
 
     @Override
@@ -65,10 +56,7 @@ public class PaymentService implements PaymentUseCase {
 
         payment.failPayment(command.code(), command.message());
 
-        return new FailPaymentResult(
-                payment.getPaymentId(),
-                payment.getPaymentStatus(),
-                payment.getUpdatedAt()
-        );
+        FailPaymentResult result = FailPaymentResult.from(payment);
+        return result;
     }
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
@@ -1,9 +1,15 @@
 package com.trustamarket.paymentservice.paymentservice.application.service;
 
 import com.trustamarket.paymentservice.paymentservice.application.dto.command.CreatePaymentCommand;
+import com.trustamarket.paymentservice.paymentservice.application.dto.command.FailPaymentCommand;
+import com.trustamarket.paymentservice.paymentservice.application.dto.command.SucceededPaymentCommand;
 import com.trustamarket.paymentservice.paymentservice.application.dto.result.CreatePaymentResult;
+import com.trustamarket.paymentservice.paymentservice.application.dto.result.FailPaymentResult;
+import com.trustamarket.paymentservice.paymentservice.application.dto.result.SucceededPaymentResult;
 import com.trustamarket.paymentservice.paymentservice.application.port.PaymentUseCase;
 import com.trustamarket.paymentservice.paymentservice.domain.entity.Payment;
+import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentErrorCode;
+import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentException;
 import com.trustamarket.paymentservice.paymentservice.domain.repository.PaymentRepository;
 import com.trustamarket.paymentservice.paymentservice.domain.vo.Amount;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +25,10 @@ public class PaymentService implements PaymentUseCase {
     @Override
     @Transactional
     public CreatePaymentResult createPayment(CreatePaymentCommand command) {
+        if (paymentRepository.existsByChargeId(command.chargeId())) {
+            throw new PaymentException(PaymentErrorCode.DUPLICATE_CHARGE_ID);
+        }
+
         Payment payment = Payment.create(command.chargeId(), Amount.of(command.amount()));
 
         Payment savedPayment = paymentRepository.save(payment);
@@ -29,6 +39,35 @@ public class PaymentService implements PaymentUseCase {
                 savedPayment.getPaymentStatus(),
                 savedPayment.getAmount(),
                 savedPayment.getCreatedAt()
+        );
+    }
+
+    @Override
+    @Transactional
+    public SucceededPaymentResult succeededPayment(SucceededPaymentCommand command) {
+        Payment payment = paymentRepository.findById(command.paymentId());
+
+        payment.successPayment(command.paymentKey(), command.amount());
+
+        return new SucceededPaymentResult(
+                payment.getPaymentId(),
+                payment.getPaymentStatus(),
+                payment.getAmount(),
+                payment.getUpdatedAt()
+        );
+    }
+
+    @Override
+    @Transactional
+    public FailPaymentResult failPayment(FailPaymentCommand command) {
+        Payment payment = paymentRepository.findById(command.paymentId());
+
+        payment.failPayment(command.code(), command.message());
+
+        return new FailPaymentResult(
+                payment.getPaymentId(),
+                payment.getPaymentStatus(),
+                payment.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
@@ -19,12 +19,13 @@ public class PaymentService implements PaymentUseCase {
     @Override
     @Transactional
     public CreatePaymentResult createPayment(CreatePaymentCommand command) {
-        Payment payment = Payment.create(Amount.of(command.amount()));
+        Payment payment = Payment.create(chargeId, Amount.of(command.amount()));
 
         Payment savedPayment = paymentRepository.save(payment);
 
         return new CreatePaymentResult(
                 savedPayment.getPaymentId(),
+                savedPayment.getChargeId(),
                 savedPayment.getPaymentStatus(),
                 savedPayment.getAmount(),
                 savedPayment.getCreatedAt()

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
@@ -19,7 +19,7 @@ public class PaymentService implements PaymentUseCase {
     @Override
     @Transactional
     public CreatePaymentResult createPayment(CreatePaymentCommand command) {
-        Payment payment = Payment.create(chargeId, Amount.of(command.amount()));
+        Payment payment = Payment.create(command.chargeId(), Amount.of(command.amount()));
 
         Payment savedPayment = paymentRepository.save(payment);
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
@@ -13,6 +13,7 @@ import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentEx
 import com.trustamarket.paymentservice.paymentservice.domain.repository.PaymentRepository;
 import com.trustamarket.paymentservice.paymentservice.domain.vo.Amount;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,21 +26,21 @@ public class PaymentService implements PaymentUseCase {
     @Override
     @Transactional
     public CreatePaymentResult createPayment(CreatePaymentCommand command) {
-        if (paymentRepository.existsByChargeId(command.chargeId())) {
+        try{
+            Payment payment = Payment.create(command.chargeId(), Amount.of(command.amount()));
+            Payment savedPayment = paymentRepository.saveandFlush(payment);
+
+            return new CreatePaymentResult(
+                    savedPayment.getPaymentId(),
+                    savedPayment.getChargeId(),
+                    savedPayment.getPaymentStatus(),
+                    savedPayment.getAmount(),
+                    savedPayment.getCreatedAt()
+            );
+
+        }catch (DataIntegrityViolationException e){
             throw new PaymentException(PaymentErrorCode.DUPLICATE_CHARGE_ID);
         }
-
-        Payment payment = Payment.create(command.chargeId(), Amount.of(command.amount()));
-
-        Payment savedPayment = paymentRepository.save(payment);
-
-        return new CreatePaymentResult(
-                savedPayment.getPaymentId(),
-                savedPayment.getChargeId(),
-                savedPayment.getPaymentStatus(),
-                savedPayment.getAmount(),
-                savedPayment.getCreatedAt()
-        );
     }
 
     @Override

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/config/DevSecurityConfig.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/config/DevSecurityConfig.java
@@ -1,0 +1,27 @@
+package com.trustamarket.paymentservice.paymentservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+// 인증 미구현 동안 401 우회용. 인증 붙이면 통째로 삭제할 것.
+@Configuration
+@Profile({"local", "dev"})
+public class DevSecurityConfig {
+
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    public SecurityFilterChain devFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .securityMatcher("/api/**") // ⭐ 전체 말고 API만!
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/Payment.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/Payment.java
@@ -1,5 +1,6 @@
 package com.trustamarket.paymentservice.paymentservice.domain.entity;
 
+import com.trustamarket.common.domain.BaseCreatedEntity;
 import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
 import com.trustamarket.paymentservice.paymentservice.domain.vo.Amount;
 import jakarta.persistence.CascadeType;
@@ -15,7 +16,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -24,7 +24,7 @@ import java.util.UUID;
 @Entity
 @Table(name = "p_payments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Payment {
+public class Payment extends BaseCreatedEntity {
 
 	@Id
 	@Column(name = "payment_id", nullable = false, updatable = false)
@@ -47,15 +47,6 @@ public class Payment {
 	@Column(name = "version", nullable = false)
 	private Integer version;
 
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private Instant createdAt;
-
-	@Column(name = "created_by")
-	private UUID createdBy;
-
-	@Column(name = "updated_at")
-	private Instant updatedAt;
-
 	@OneToMany(mappedBy = "payment", cascade = CascadeType.PERSIST)
 	private List<PaymentTx> transactions = new ArrayList<>();
 
@@ -69,7 +60,6 @@ public class Payment {
 		payment.chargeId = chargeId;
 		payment.paymentStatus = PaymentStatus.REQUESTED;
 		payment.amount = amount.value();
-		payment.createdAt = Instant.now();
 
 		payment.addTransaction(PaymentTx.createRequest(amount));
 		return payment;
@@ -85,7 +75,6 @@ public class Payment {
 
 		this.paymentStatus = PaymentStatus.SUCCESS;
 		this.paymentKey = paymentKey;
-		this.updatedAt = Instant.now();
 
 		this.addTransaction(PaymentTx.createSuccess(Amount.of(approvedAmount), paymentKey));
 	}
@@ -95,7 +84,6 @@ public class Payment {
 			throw new IllegalStateException("결제 상태 전이 오류");
 		}
 		this.paymentStatus = PaymentStatus.FAILED;
-		this.updatedAt = Instant.now();
 
 		this.addTransaction(PaymentTx.createFail(Amount.of(amount), pgCode, pgMessage));
 	}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/Payment.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/Payment.java
@@ -1,6 +1,7 @@
 package com.trustamarket.paymentservice.paymentservice.domain.entity;
 
 import com.trustamarket.common.domain.BaseCreatedEntity;
+import com.trustamarket.common.domain.BaseTimeEntity;
 import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
 import com.trustamarket.paymentservice.paymentservice.domain.vo.Amount;
 import jakarta.persistence.CascadeType;
@@ -24,7 +25,7 @@ import java.util.UUID;
 @Entity
 @Table(name = "p_payments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Payment extends BaseCreatedEntity {
+public class Payment extends BaseTimeEntity {
 
 	@Id
 	@Column(name = "payment_id", nullable = false, updatable = false)
@@ -64,6 +65,7 @@ public class Payment extends BaseCreatedEntity {
 		payment.addTransaction(PaymentTx.createRequest(amount));
 		return payment;
 	}
+
 
 	public void successPayment(String paymentKey, long approvedAmount) {
 		if(this.paymentStatus != PaymentStatus.REQUESTED){

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/Payment.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/Payment.java
@@ -1,6 +1,5 @@
 package com.trustamarket.paymentservice.paymentservice.domain.entity;
 
-import com.trustamarket.common.domain.BaseCreatedEntity;
 import com.trustamarket.common.domain.BaseTimeEntity;
 import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
 import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentErrorCode;

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/Payment.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/Payment.java
@@ -30,6 +30,9 @@ public class Payment {
 	@Column(name = "payment_id", nullable = false, updatable = false)
 	private UUID paymentId;
 
+	@Column(name = "charge_id", nullable = false, updatable = false, unique = true)
+	private UUID chargeId;
+
 	@Column(name="payment_key", length = 200)
 	private String paymentKey;
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/Payment.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/Payment.java
@@ -3,6 +3,8 @@ package com.trustamarket.paymentservice.paymentservice.domain.entity;
 import com.trustamarket.common.domain.BaseCreatedEntity;
 import com.trustamarket.common.domain.BaseTimeEntity;
 import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
+import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentErrorCode;
+import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentException;
 import com.trustamarket.paymentservice.paymentservice.domain.vo.Amount;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -69,10 +71,10 @@ public class Payment extends BaseTimeEntity {
 
 	public void successPayment(String paymentKey, long approvedAmount) {
 		if(this.paymentStatus != PaymentStatus.REQUESTED){
-			throw new IllegalStateException("결제 상태 전이 오류");
+			throw new PaymentException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
 		}
 		if (approvedAmount != this.amount) {
-			throw new IllegalStateException("PG 승인 금액 불일치");
+			throw new PaymentException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
 		}
 
 		this.paymentStatus = PaymentStatus.SUCCESS;
@@ -83,7 +85,7 @@ public class Payment extends BaseTimeEntity {
 
 	public void failPayment(String pgCode,  String pgMessage) {
 		if(this.paymentStatus != PaymentStatus.REQUESTED){
-			throw new IllegalStateException("결제 상태 전이 오류");
+			throw new PaymentException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
 		}
 		this.paymentStatus = PaymentStatus.FAILED;
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/Payment.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/Payment.java
@@ -60,11 +60,13 @@ public class Payment {
 	private List<PaymentTx> transactions = new ArrayList<>();
 
 	public static Payment create(
+			UUID chargeId,
 			Amount amount
 	) {
 		Payment payment = new Payment();
 
 		payment.paymentId = UUID.randomUUID();
+		payment.chargeId = chargeId;
 		payment.paymentStatus = PaymentStatus.REQUESTED;
 		payment.amount = amount.value();
 		payment.createdAt = Instant.now();

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/PaymentTx.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/entity/PaymentTx.java
@@ -1,5 +1,6 @@
 package com.trustamarket.paymentservice.paymentservice.domain.entity;
 
+import com.trustamarket.common.domain.BaseCreatedEntity;
 import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentTxType;
 import com.trustamarket.paymentservice.paymentservice.domain.vo.Amount;
 import jakarta.persistence.Column;
@@ -15,14 +16,13 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.Instant;
 import java.util.UUID;
 
 @Getter
 @Entity
 @Table(name = "p_payment_transactions")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PaymentTx {
+public class PaymentTx extends BaseCreatedEntity {
 
 	@Id
 	@Column(name = "payment_tx_id", nullable = false, updatable = false)
@@ -48,9 +48,6 @@ public class PaymentTx {
 	@Column(name = "pg_response_message", length = 255)
 	private String pgResponseMessage;
 
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private Instant createdAt;
-
 	public static PaymentTx createRequest(
 			Amount amount
 	) {
@@ -59,7 +56,6 @@ public class PaymentTx {
 		tx.paymentTxId = UUID.randomUUID();
 		tx.txType = PaymentTxType.REQUESTED;
 		tx.amount = amount.value();
-		tx.createdAt = Instant.now();
         return tx;
     }
 
@@ -74,7 +70,6 @@ public class PaymentTx {
 		tx.txType = PaymentTxType.SUCCESS;
 		tx.amount = amount.value();
 		tx.paymentKey = paymentKey;
-		tx.createdAt = Instant.now();
 		return tx;
 	}
 
@@ -90,7 +85,6 @@ public class PaymentTx {
 		tx.amount = amount.value();
 		tx.pgResponseCode = pgResponseCode;
 		tx.pgResponseMessage = pgResponseMessage;
-		tx.createdAt = Instant.now();
 		return tx;
 	}
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/exception/PaymentErrorCode.java
@@ -1,0 +1,30 @@
+package com.trustamarket.paymentservice.paymentservice.domain.exception;
+
+import com.trustamarket.common.exception.ErrorCodeSpec;
+import org.springframework.http.HttpStatus;
+
+public enum PaymentErrorCode implements ErrorCodeSpec {
+
+    PAYMENT_NOT_FOUND("PAYMENT_NOT_FOUND", "결제를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, "payment"),
+    DUPLICATE_CHARGE_ID("DUPLICATE_CHARGE_ID","이미 결제가 존재하는 충전 요청입니다.", HttpStatus.CONFLICT, null),
+    INVALID_PAYMENT_STATUS("INVALID_PAYMENT_STATUS","결제 상태 전이 오류입니다.", HttpStatus.CONFLICT, null),
+    PAYMENT_AMOUNT_MISMATCH("PAYMENT_AMOUNT_MISMATCH","PG 승인 금액이 일치하지 않습니다.", HttpStatus.BAD_REQUEST, null);
+
+    private final String code;
+    private final String field;
+    private final String message;
+    private final HttpStatus status;
+
+    PaymentErrorCode(String code, String message, HttpStatus status, String field) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+        this.field = field;
+    }
+
+    @Override public String getCode() { return code; }
+    @Override public HttpStatus getStatus() { return status; }
+    @Override public String getMessage() { return message; }
+    @Override public String getField() { return field; }
+
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/exception/PaymentException.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/exception/PaymentException.java
@@ -1,0 +1,13 @@
+package com.trustamarket.paymentservice.paymentservice.domain.exception;
+
+import com.trustamarket.common.exception.CustomException;
+import com.trustamarket.common.exception.ErrorCodeSpec;
+
+public class PaymentException extends CustomException {
+    private final ErrorCodeSpec errorCode;
+
+    public PaymentException(ErrorCodeSpec errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/repository/PaymentRepository.java
@@ -6,6 +6,6 @@ import java.util.UUID;
 
 public interface PaymentRepository {
     boolean existsByChargeId(UUID chargeId);
-    Payment saveandFlush(Payment payment);
+    Payment saveAndFlush(Payment payment);
     Payment findById(UUID PaymentId);
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/repository/PaymentRepository.java
@@ -6,6 +6,6 @@ import java.util.UUID;
 
 public interface PaymentRepository {
     boolean existsByChargeId(UUID chargeId);
-    Payment save(Payment payment);
+    Payment saveandFlush(Payment payment);
     Payment findById(UUID PaymentId);
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/repository/PaymentRepository.java
@@ -2,6 +2,10 @@ package com.trustamarket.paymentservice.paymentservice.domain.repository;
 
 import com.trustamarket.paymentservice.paymentservice.domain.entity.Payment;
 
+import java.util.UUID;
+
 public interface PaymentRepository {
+    boolean existsByChargeId(UUID chargeId);
     Payment save(Payment payment);
+    Payment findById(UUID PaymentId);
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/PaymentJpaRepository.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/PaymentJpaRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.trustamarket.paymentservice.paymentservice.domain.entity.Payment;
 
 public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
+    boolean existsByChargeId(UUID chargeId);
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/PaymentJpaRepository.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/PaymentJpaRepository.java
@@ -1,10 +1,9 @@
 package com.trustamarket.paymentservice.paymentservice.infrastructure;
 
-import java.util.UUID;
-
+import com.trustamarket.paymentservice.paymentservice.domain.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.trustamarket.paymentservice.paymentservice.domain.entity.Payment;
+import java.util.UUID;
 
 public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
     boolean existsByChargeId(UUID chargeId);

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/PaymentRepositoryAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/PaymentRepositoryAdapter.java
@@ -21,8 +21,9 @@ public class PaymentRepositoryAdapter implements PaymentRepository {
     }
 
     @Override
-    public Payment save(Payment payment) {
-        return paymentJpaRepository.save(payment);
+    public Payment saveandFlush(Payment payment) {
+        return paymentJpaRepository.saveAndFlush(payment);
+
     }
 
     @Override

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/PaymentRepositoryAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/PaymentRepositoryAdapter.java
@@ -21,7 +21,7 @@ public class PaymentRepositoryAdapter implements PaymentRepository {
     }
 
     @Override
-    public Payment saveandFlush(Payment payment) {
+    public Payment saveAndFlush(Payment payment) {
         return paymentJpaRepository.saveAndFlush(payment);
 
     }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/PaymentRepositoryAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/PaymentRepositoryAdapter.java
@@ -1,9 +1,13 @@
 package com.trustamarket.paymentservice.paymentservice.infrastructure;
 
 import com.trustamarket.paymentservice.paymentservice.domain.entity.Payment;
+import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentErrorCode;
+import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentException;
 import com.trustamarket.paymentservice.paymentservice.domain.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
 
 @Repository
 @RequiredArgsConstructor
@@ -12,7 +16,18 @@ public class PaymentRepositoryAdapter implements PaymentRepository {
     private final PaymentJpaRepository paymentJpaRepository;
 
     @Override
+    public boolean existsByChargeId(UUID chargeId) {
+        return paymentJpaRepository.existsByChargeId(chargeId);
+    }
+
+    @Override
     public Payment save(Payment payment) {
         return paymentJpaRepository.save(payment);
+    }
+
+    @Override
+    public Payment findById(UUID paymentId){
+        Payment payment = paymentJpaRepository.findById(paymentId).orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+        return payment;
     }
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
@@ -17,6 +17,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,20 +35,16 @@ public class PaymentController {
     private final PaymentUseCase paymentUseCase;
 
     @PostMapping
-    public CommonResponse<CreatePaymentResponse> createPayment(@Valid @RequestBody CreatePaymentRequest request) {
+    public ResponseEntity<CommonResponse<CreatePaymentResponse>> createPayment(@Valid @RequestBody CreatePaymentRequest request) {
         CreatePaymentCommand command = new CreatePaymentCommand(request.chargeId(), request.amount());
 
         CreatePaymentResult result = paymentUseCase.createPayment(command);
 
-        CreatePaymentResponse response = new CreatePaymentResponse(
-                result.paymentId(),
-                result.chargeId(),
-                result.paymentStatus().name(),
-                result.amount(),
-                result.createdAt()
-        );
+        CreatePaymentResponse response = CreatePaymentResponse.from(result);
 
-        return new CommonResponse<>(HttpStatus.CREATED.value(), response);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new CommonResponse<>(HttpStatus.CREATED.value(), response));
     }
 
     @PostMapping("/{paymentId}/success")
@@ -60,12 +57,7 @@ public class PaymentController {
 
         SucceededPaymentResult result = paymentUseCase.succeededPayment(command);
 
-        SucceededPaymentResponse response = new SucceededPaymentResponse(
-                result.paymentId(),
-                result.paymentStatus(),
-                result.amount(),
-                result.updatedAt()
-        );
+        SucceededPaymentResponse response = SucceededPaymentResponse.from(result);
 
         return new CommonResponse<>(HttpStatus.OK.value(), response);
     }
@@ -75,16 +67,12 @@ public class PaymentController {
             @PathVariable UUID paymentId,
             @RequestParam @NotBlank String code,
             @RequestParam @NotBlank String message
-    ){
+    ) {
         FailPaymentCommand command = new FailPaymentCommand(paymentId, code, message);
 
         FailPaymentResult result = paymentUseCase.failPayment(command);
 
-        FailPaymentResponse response = new FailPaymentResponse(
-                result.paymentId(),
-                result.paymentStatus(),
-                result.updatedAt()
-        );
+        FailPaymentResponse response = FailPaymentResponse.from(result);
 
         return new CommonResponse<>(HttpStatus.OK.value(), response);
     }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
@@ -12,6 +12,7 @@ import com.trustamarket.paymentservice.paymentservice.presentation.dto.request.C
 import com.trustamarket.paymentservice.paymentservice.presentation.dto.response.CreatePaymentResponse;
 import com.trustamarket.paymentservice.paymentservice.presentation.dto.response.FailPaymentResponse;
 import com.trustamarket.paymentservice.paymentservice.presentation.dto.response.SucceededPaymentResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,7 +32,7 @@ public class PaymentController {
     private final PaymentUseCase paymentUseCase;
 
     @PostMapping
-    public CommonResponse<CreatePaymentResponse> createPayment(@RequestBody CreatePaymentRequest request) {
+    public CommonResponse<CreatePaymentResponse> createPayment(@Valid @RequestBody CreatePaymentRequest request) {
         CreatePaymentCommand command = new CreatePaymentCommand(request.chargeId(), request.amount());
 
         CreatePaymentResult result = paymentUseCase.createPayment(command);

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
@@ -21,12 +21,13 @@ public class PaymentController {
 
     @PostMapping
     public ResponseEntity<CreatePaymentResponse> createPayment(@RequestBody CreatePaymentRequest request) {
-        CreatePaymentCommand command = new CreatePaymentCommand(request.amount());
+        CreatePaymentCommand command = new CreatePaymentCommand(request.chargeId(), request.amount());
 
         CreatePaymentResult result = paymentUseCase.createPayment(command);
 
         CreatePaymentResponse response = new CreatePaymentResponse(
                 result.paymentId(),
+                result.chargeId(),
                 result.paymentStatus().name(),
                 result.amount(),
                 result.createdAt()

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
@@ -2,19 +2,26 @@ package com.trustamarket.paymentservice.paymentservice.presentation;
 
 import com.trustamarket.common.response.CommonResponse;
 import com.trustamarket.paymentservice.paymentservice.application.dto.command.CreatePaymentCommand;
-import com.trustamarket.paymentservice.paymentservice.application.port.PaymentUseCase;
+import com.trustamarket.paymentservice.paymentservice.application.dto.command.FailPaymentCommand;
+import com.trustamarket.paymentservice.paymentservice.application.dto.command.SucceededPaymentCommand;
 import com.trustamarket.paymentservice.paymentservice.application.dto.result.CreatePaymentResult;
+import com.trustamarket.paymentservice.paymentservice.application.dto.result.FailPaymentResult;
+import com.trustamarket.paymentservice.paymentservice.application.dto.result.SucceededPaymentResult;
+import com.trustamarket.paymentservice.paymentservice.application.port.PaymentUseCase;
 import com.trustamarket.paymentservice.paymentservice.presentation.dto.request.CreatePaymentRequest;
 import com.trustamarket.paymentservice.paymentservice.presentation.dto.response.CreatePaymentResponse;
+import com.trustamarket.paymentservice.paymentservice.presentation.dto.response.FailPaymentResponse;
+import com.trustamarket.paymentservice.paymentservice.presentation.dto.response.SucceededPaymentResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/payments")
@@ -38,5 +45,44 @@ public class PaymentController {
         );
 
         return new CommonResponse<>(HttpStatus.CREATED.value(), response);
+    }
+
+    @PostMapping("/{paymentId}/success")
+    public CommonResponse<SucceededPaymentResponse> successPayment(
+            @PathVariable UUID paymentId,
+            @RequestParam String paymentKey,
+            @RequestParam long amount
+    ){
+        SucceededPaymentCommand command = new SucceededPaymentCommand(paymentId, paymentKey, amount);
+
+        SucceededPaymentResult result = paymentUseCase.succeededPayment(command);
+
+        SucceededPaymentResponse response = new SucceededPaymentResponse(
+                result.paymentId(),
+                result.paymentStatus(),
+                result.amount(),
+                result.updatedAt()
+        );
+
+        return new CommonResponse<>(HttpStatus.OK.value(), response);
+    }
+
+    @PostMapping("/{paymentId}/failure")
+    public CommonResponse<FailPaymentResponse> failPayment(
+            @PathVariable UUID paymentId,
+            @RequestParam String code,
+            @RequestParam String message
+    ){
+        FailPaymentCommand command = new FailPaymentCommand(paymentId, code, message);
+
+        FailPaymentResult result = paymentUseCase.failPayment(command);
+
+        FailPaymentResponse response = new FailPaymentResponse(
+                result.paymentId(),
+                result.paymentStatus(),
+                result.updatedAt()
+        );
+
+        return new CommonResponse<>(HttpStatus.OK.value(), response);
     }
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
@@ -1,16 +1,20 @@
 package com.trustamarket.paymentservice.paymentservice.presentation;
 
+import com.trustamarket.common.response.CommonResponse;
 import com.trustamarket.paymentservice.paymentservice.application.dto.command.CreatePaymentCommand;
 import com.trustamarket.paymentservice.paymentservice.application.port.PaymentUseCase;
 import com.trustamarket.paymentservice.paymentservice.application.dto.result.CreatePaymentResult;
 import com.trustamarket.paymentservice.paymentservice.presentation.dto.request.CreatePaymentRequest;
 import com.trustamarket.paymentservice.paymentservice.presentation.dto.response.CreatePaymentResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping("/api/payments")
@@ -20,7 +24,7 @@ public class PaymentController {
     private final PaymentUseCase paymentUseCase;
 
     @PostMapping
-    public ResponseEntity<CreatePaymentResponse> createPayment(@RequestBody CreatePaymentRequest request) {
+    public CommonResponse<CreatePaymentResponse> createPayment(@RequestBody CreatePaymentRequest request) {
         CreatePaymentCommand command = new CreatePaymentCommand(request.chargeId(), request.amount());
 
         CreatePaymentResult result = paymentUseCase.createPayment(command);
@@ -33,6 +37,6 @@ public class PaymentController {
                 result.createdAt()
         );
 
-        return ResponseEntity.ok(response);
+        return new CommonResponse<>(HttpStatus.CREATED.value(), response);
     }
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
@@ -13,6 +13,8 @@ import com.trustamarket.paymentservice.paymentservice.presentation.dto.response.
 import com.trustamarket.paymentservice.paymentservice.presentation.dto.response.FailPaymentResponse;
 import com.trustamarket.paymentservice.paymentservice.presentation.dto.response.SucceededPaymentResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -51,8 +53,8 @@ public class PaymentController {
     @PostMapping("/{paymentId}/success")
     public CommonResponse<SucceededPaymentResponse> successPayment(
             @PathVariable UUID paymentId,
-            @RequestParam String paymentKey,
-            @RequestParam long amount
+            @RequestParam @NotBlank String paymentKey,
+            @RequestParam @Positive long amount
     ){
         SucceededPaymentCommand command = new SucceededPaymentCommand(paymentId, paymentKey, amount);
 
@@ -71,8 +73,8 @@ public class PaymentController {
     @PostMapping("/{paymentId}/failure")
     public CommonResponse<FailPaymentResponse> failPayment(
             @PathVariable UUID paymentId,
-            @RequestParam String code,
-            @RequestParam String message
+            @RequestParam @NotBlank String code,
+            @RequestParam @NotBlank String message
     ){
         FailPaymentCommand command = new FailPaymentCommand(paymentId, code, message);
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/request/CreatePaymentRequest.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/request/CreatePaymentRequest.java
@@ -1,7 +1,11 @@
 package com.trustamarket.paymentservice.paymentservice.presentation.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 
+import java.util.UUID;
+
 public record CreatePaymentRequest (
+        @NotBlank UUID chargeId,
         @Positive long amount
 ) {}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/request/CreatePaymentRequest.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/request/CreatePaymentRequest.java
@@ -1,6 +1,5 @@
 package com.trustamarket.paymentservice.paymentservice.presentation.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/request/CreatePaymentRequest.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/request/CreatePaymentRequest.java
@@ -1,11 +1,12 @@
 package com.trustamarket.paymentservice.paymentservice.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 import java.util.UUID;
 
 public record CreatePaymentRequest (
-        @NotBlank UUID chargeId,
+        @NotNull UUID chargeId,
         @Positive long amount
 ) {}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/response/CreatePaymentResponse.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/response/CreatePaymentResponse.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 public record CreatePaymentResponse (
         UUID paymentId,
+        UUID chargeId,
         String paymentStatus,
         long amount,
         Instant createdAt

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/response/CreatePaymentResponse.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/response/CreatePaymentResponse.java
@@ -1,5 +1,7 @@
 package com.trustamarket.paymentservice.paymentservice.presentation.dto.response;
 
+import com.trustamarket.paymentservice.paymentservice.application.dto.result.CreatePaymentResult;
+
 import java.time.Instant;
 import java.util.UUID;
 
@@ -9,4 +11,14 @@ public record CreatePaymentResponse (
         String paymentStatus,
         long amount,
         Instant createdAt
-){}
+){
+    public static CreatePaymentResponse from(CreatePaymentResult result) {
+        return new CreatePaymentResponse(
+                result.paymentId(),
+                result.chargeId(),
+                result.paymentStatus().name(),
+                result.amount(),
+                result.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/response/FailPaymentResponse.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/response/FailPaymentResponse.java
@@ -1,12 +1,20 @@
 package com.trustamarket.paymentservice.paymentservice.presentation.dto.response;
 
-import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
+import com.trustamarket.paymentservice.paymentservice.application.dto.result.FailPaymentResult;
 
 import java.time.Instant;
 import java.util.UUID;
 
 public record FailPaymentResponse(
         UUID paymentId,
-        PaymentStatus paymentStatus,
+        String paymentStatus,
         Instant updatedAt
-){}
+){
+    public static FailPaymentResponse from(FailPaymentResult result) {
+        return new FailPaymentResponse(
+                result.paymentId(),
+                result.paymentStatus().name(),
+                result.updatedAt()
+        );
+    }
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/response/FailPaymentResponse.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/response/FailPaymentResponse.java
@@ -1,0 +1,12 @@
+package com.trustamarket.paymentservice.paymentservice.presentation.dto.response;
+
+import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record FailPaymentResponse(
+        UUID paymentId,
+        PaymentStatus paymentStatus,
+        Instant updatedAt
+){}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/response/SucceededPaymentResponse.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/response/SucceededPaymentResponse.java
@@ -1,13 +1,22 @@
 package com.trustamarket.paymentservice.paymentservice.presentation.dto.response;
 
-import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
+import com.trustamarket.paymentservice.paymentservice.application.dto.result.SucceededPaymentResult;
 
 import java.time.Instant;
 import java.util.UUID;
 
 public record SucceededPaymentResponse(
         UUID paymentId,
-        PaymentStatus paymentStatus,
+        String paymentStatus,
         long amount,
         Instant updatedAt
-){}
+){
+    public static SucceededPaymentResponse from(SucceededPaymentResult result){
+        return new SucceededPaymentResponse(
+                result.paymentId(),
+                result.paymentStatus().name(),
+                result.amount(),
+                result.updatedAt()
+        );
+    }
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/response/SucceededPaymentResponse.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/dto/response/SucceededPaymentResponse.java
@@ -1,0 +1,13 @@
+package com.trustamarket.paymentservice.paymentservice.presentation.dto.response;
+
+import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record SucceededPaymentResponse(
+        UUID paymentId,
+        PaymentStatus paymentStatus,
+        long amount,
+        Instant updatedAt
+){}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: payment-service

--- a/src/test/java/com/trustamarket/paymentservice/paymentservice/PaymentServiceTest.java
+++ b/src/test/java/com/trustamarket/paymentservice/paymentservice/PaymentServiceTest.java
@@ -52,7 +52,7 @@ class PaymentServiceTest {
 
             Payment payment = Payment.create(chargeId, Amount.of(amount));
             given(paymentRepository.existsByChargeId(chargeId)).willReturn(false);
-            given(paymentRepository.save(any(Payment.class))).willReturn(payment);
+            given(paymentRepository.saveAndFlush(any(Payment.class))).willReturn(payment);
 
             // when
             CreatePaymentResult result = paymentService.createPayment(command);
@@ -61,7 +61,7 @@ class PaymentServiceTest {
             assertThat(result.chargeId()).isEqualTo(chargeId);
             assertThat(result.amount()).isEqualTo(amount);
             assertThat(result.paymentStatus()).isEqualTo(PaymentStatus.REQUESTED);
-            verify(paymentRepository).save(any(Payment.class));
+            verify(paymentRepository).saveAndFlush(any(Payment.class));
         }
 
         @Test
@@ -98,7 +98,7 @@ class PaymentServiceTest {
             UUID chargeId = UUID.randomUUID();
             CreatePaymentCommand command = new CreatePaymentCommand(chargeId, 10000L);
             given(paymentRepository.existsByChargeId(chargeId)).willReturn(false);
-            given(paymentRepository.save(any(Payment.class))).willThrow(new RuntimeException("DB 저장 실패"));
+            given(paymentRepository.saveAndFlush(any(Payment.class))).willThrow(new RuntimeException("DB 저장 실패"));
 
             // when & then
             assertThatThrownBy(() -> paymentService.createPayment(command))

--- a/src/test/java/com/trustamarket/paymentservice/paymentservice/PaymentServiceTest.java
+++ b/src/test/java/com/trustamarket/paymentservice/paymentservice/PaymentServiceTest.java
@@ -1,0 +1,218 @@
+package com.trustamarket.paymentservice.paymentservice;
+
+import com.trustamarket.paymentservice.paymentservice.application.dto.command.CreatePaymentCommand;
+import com.trustamarket.paymentservice.paymentservice.application.dto.command.FailPaymentCommand;
+import com.trustamarket.paymentservice.paymentservice.application.dto.command.SucceededPaymentCommand;
+import com.trustamarket.paymentservice.paymentservice.application.dto.result.CreatePaymentResult;
+import com.trustamarket.paymentservice.paymentservice.application.dto.result.FailPaymentResult;
+import com.trustamarket.paymentservice.paymentservice.application.dto.result.SucceededPaymentResult;
+import com.trustamarket.paymentservice.paymentservice.application.service.PaymentService;
+import com.trustamarket.paymentservice.paymentservice.domain.entity.Payment;
+import com.trustamarket.paymentservice.paymentservice.domain.enums.PaymentStatus;
+import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentErrorCode;
+import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentException;
+import com.trustamarket.paymentservice.paymentservice.domain.repository.PaymentRepository;
+import com.trustamarket.paymentservice.paymentservice.domain.vo.Amount;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    @Nested
+    @DisplayName("결제 생성")
+    class CreatePayment {
+
+        @Test
+        @DisplayName("정상 - 결제 생성 성공")
+        void createPayment_success() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            long amount = 10000L;
+            CreatePaymentCommand command = new CreatePaymentCommand(chargeId, amount);
+
+            Payment payment = Payment.create(chargeId, Amount.of(amount));
+            given(paymentRepository.existsByChargeId(chargeId)).willReturn(false);
+            given(paymentRepository.save(any(Payment.class))).willReturn(payment);
+
+            // when
+            CreatePaymentResult result = paymentService.createPayment(command);
+
+            // then
+            assertThat(result.chargeId()).isEqualTo(chargeId);
+            assertThat(result.amount()).isEqualTo(amount);
+            assertThat(result.paymentStatus()).isEqualTo(PaymentStatus.REQUESTED);
+            verify(paymentRepository).save(any(Payment.class));
+        }
+
+        @Test
+        @DisplayName("실패 - 중복 chargeId로 결제 생성 시 PaymentException(DUPLICATE_CHARGE_ID)")
+        void createPayment_duplicateChargeId() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            CreatePaymentCommand command = new CreatePaymentCommand(chargeId, 10000L);
+            given(paymentRepository.existsByChargeId(chargeId)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.createPayment(command))
+                    .isInstanceOf(PaymentException.class);
+        }
+
+        @Test
+        @DisplayName("예외 - 금액이 0 이하일 때 IllegalArgumentException")
+        void createPayment_invalidAmount() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            CreatePaymentCommand command = new CreatePaymentCommand(chargeId, 0L);
+            given(paymentRepository.existsByChargeId(chargeId)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.createPayment(command))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("결제 금액은 0보다 커야 합니다.");
+        }
+
+        @Test
+        @DisplayName("예외 - DB 저장 실패 시 예외 전파")
+        void createPayment_dbSaveFail() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            CreatePaymentCommand command = new CreatePaymentCommand(chargeId, 10000L);
+            given(paymentRepository.existsByChargeId(chargeId)).willReturn(false);
+            given(paymentRepository.save(any(Payment.class))).willThrow(new RuntimeException("DB 저장 실패"));
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.createPayment(command))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("DB 저장 실패");
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 성공 처리")
+    class SucceededPayment {
+
+        @Test
+        @DisplayName("정상 - 결제 성공 처리")
+        void succeededPayment_success() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            long amount = 10000L;
+            Payment payment = Payment.create(chargeId, Amount.of(amount));
+            UUID paymentId = payment.getPaymentId();
+
+            SucceededPaymentCommand command = new SucceededPaymentCommand(paymentId, "test_key_123", amount);
+            given(paymentRepository.findById(paymentId)).willReturn(payment);
+
+            // when
+            SucceededPaymentResult result = paymentService.succeededPayment(command);
+
+            // then
+            assertThat(result.paymentStatus()).isEqualTo(PaymentStatus.SUCCESS);
+            assertThat(result.amount()).isEqualTo(amount);
+        }
+
+        @Test
+        @DisplayName("예외 - 존재하지 않는 paymentId로 PaymentException(PAYMENT_NOT_FOUND)")
+        void succeededPayment_notFound() {
+            // given
+            UUID paymentId = UUID.randomUUID();
+            SucceededPaymentCommand command = new SucceededPaymentCommand(paymentId, "test_key_123", 10000L);
+            given(paymentRepository.findById(paymentId))
+                    .willThrow(new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.succeededPayment(command))
+                    .isInstanceOf(PaymentException.class);
+        }
+
+        @Test
+        @DisplayName("예외 - PG 승인 금액 불일치 시 PaymentException(PAYMENT_AMOUNT_MISMATCH)")
+        void succeededPayment_amountMismatch() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            Payment payment = Payment.create(chargeId, Amount.of(10000L));
+            UUID paymentId = payment.getPaymentId();
+
+            SucceededPaymentCommand command = new SucceededPaymentCommand(paymentId, "test_key_123", 9000L);
+            given(paymentRepository.findById(paymentId)).willReturn(payment);
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.succeededPayment(command))
+                    .isInstanceOf(PaymentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 실패 처리")
+    class FailPayment {
+
+        @Test
+        @DisplayName("정상 - 결제 실패 처리")
+        void failPayment_success() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            Payment payment = Payment.create(chargeId, Amount.of(10000L));
+            UUID paymentId = payment.getPaymentId();
+
+            FailPaymentCommand command = new FailPaymentCommand(paymentId, "CANCEL", "사용자 취소");
+            given(paymentRepository.findById(paymentId)).willReturn(payment);
+
+            // when
+            FailPaymentResult result = paymentService.failPayment(command);
+
+            // then
+            assertThat(result.paymentStatus()).isEqualTo(PaymentStatus.FAILED);
+        }
+
+        @Test
+        @DisplayName("예외 - 존재하지 않는 paymentId로 PaymentException(PAYMENT_NOT_FOUND)")
+        void failPayment_notFound() {
+            // given
+            UUID paymentId = UUID.randomUUID();
+            FailPaymentCommand command = new FailPaymentCommand(paymentId, "CANCEL", "사용자 취소");
+            given(paymentRepository.findById(paymentId))
+                    .willThrow(new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.failPayment(command))
+                    .isInstanceOf(PaymentException.class);
+        }
+
+        @Test
+        @DisplayName("예외 - REQUESTED 상태가 아닌 결제 실패 처리 시 PaymentException(INVALID_PAYMENT_STATUS)")
+        void failPayment_invalidStatus() {
+            // given
+            UUID chargeId = UUID.randomUUID();
+            Payment payment = Payment.create(chargeId, Amount.of(10000L));
+            payment.successPayment("test_key", 10000L); // 이미 SUCCESS 상태
+            UUID paymentId = payment.getPaymentId();
+
+            FailPaymentCommand command = new FailPaymentCommand(paymentId, "CANCEL", "사용자 취소");
+            given(paymentRepository.findById(paymentId)).willReturn(payment);
+
+            // when & then
+            assertThatThrownBy(() -> paymentService.failPayment(command))
+                    .isInstanceOf(PaymentException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 설명

- 결제 성공/실패 시 상태 업데이트와 관련 정보를 저장하는 API를 구현하였습니다.
- 공통모듈 적용(응답, 예외처리, baseEntity)

## 📌 관련 이슈

close #4 

## ✅ 주요 변경 사항

- 이전 이슈에서 추가못한 chargeId를 추가하였습니다.
- 결제 성공/실패시 상태와 정보 업데이트를 구현하였습니다.
- 공통 모듈 적용했습니다(응답, 예외처리, BaseEntity)
- 단위 테스트코드 작성했습니다. (생성, 성공/실패 업데이트, 실패)

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 결제 성공(/api/payments/{paymentId}/success) 및 실패(/api/payments/{paymentId}/failure)용 POST 엔드포인트 추가

* **응답/요구사항**
  * 결제 생성 요청/응답에 chargeId(청구 ID) 필수 추가 및 입력 유효성 검사 강화
  * 생성 시 HTTP 201, 성공/실패는 HTTP 200으로 응답 표준화
  * 성공/실패 응답 타입 추가

* **보안(개발)**
  * 로컬/개발 환경에서 API 요청을 인증 없이 허용하는 설정 추가

* **오류 처리 개선**
  * 중복 청구 ID 등 도메인별 명확한 오류 코드와 예외 매핑 추가

* **테스트**
  * 생성·성공·실패 흐름을 검증하는 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->