### PR TITLE
[feature] 충전 완료 시 포인트 지갑 반영, 프론트 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 .env
 application-local.yml
+.DS_Store

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/port/WalletPort.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/port/WalletPort.java
@@ -1,7 +1,8 @@
 package com.trustamarket.paymentservice.paymentservice.application.port;
 
+import com.trustamarket.common.response.CommonResponse;
 import java.util.UUID;
 
 public interface WalletPort {
-    void pointToWallet(UUID paymentId, long amount);
+    CommonResponse<Void> pointToWallet(UUID paymentId, long amount);
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/port/WalletPort.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/port/WalletPort.java
@@ -1,0 +1,7 @@
+package com.trustamarket.paymentservice.paymentservice.application.port;
+
+import java.util.UUID;
+
+public interface WalletPort {
+    void pointToWallet(UUID paymentId, long amount);
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
@@ -16,11 +16,13 @@ import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentEx
 import com.trustamarket.paymentservice.paymentservice.domain.repository.PaymentRepository;
 import com.trustamarket.paymentservice.paymentservice.domain.vo.Amount;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class PaymentService implements PaymentUseCase {
 
@@ -56,10 +58,15 @@ public class PaymentService implements PaymentUseCase {
         );
 
         payment.successPayment(command.paymentKey(), command.amount());
-
-        walletPort.pointToWallet(command.paymentId(), command.amount());
-
         SucceededPaymentResult result = SucceededPaymentResult.from(payment);
+
+        try {
+            walletPort.pointToWallet(command.paymentId(), command.amount());
+        } catch (Exception e){
+            log.error("포인트 적립 실패", e);
+            // todo : 포인트 적립 실패 로직
+        }
+
         return result;
     }
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/application/service/PaymentService.java
@@ -9,6 +9,7 @@ import com.trustamarket.paymentservice.paymentservice.application.dto.result.Suc
 import com.trustamarket.paymentservice.paymentservice.application.dto.result.TossConfirmResult;
 import com.trustamarket.paymentservice.paymentservice.application.port.PaymentUseCase;
 import com.trustamarket.paymentservice.paymentservice.application.port.TossPaymentPort;
+import com.trustamarket.paymentservice.paymentservice.application.port.WalletPort;
 import com.trustamarket.paymentservice.paymentservice.domain.entity.Payment;
 import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentErrorCode;
 import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentException;
@@ -25,6 +26,7 @@ public class PaymentService implements PaymentUseCase {
 
     private final PaymentRepository paymentRepository;
     private final TossPaymentPort tossPaymentPort;
+    private final WalletPort walletPort;
 
     @Override
     @Transactional
@@ -54,6 +56,8 @@ public class PaymentService implements PaymentUseCase {
         );
 
         payment.successPayment(command.paymentKey(), command.amount());
+
+        walletPort.pointToWallet(command.paymentId(), command.amount());
 
         SucceededPaymentResult result = SucceededPaymentResult.from(payment);
         return result;

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/exception/PaymentErrorCode.java
@@ -10,7 +10,8 @@ public enum PaymentErrorCode implements ErrorCodeSpec {
     INVALID_PAYMENT_STATUS("INVALID_PAYMENT_STATUS","결제 상태 전이 오류입니다.", HttpStatus.CONFLICT, null),
     INVALID_PAYMENT_KEY("INVALID_PAYMENT_KEY", "결제키가 유효하지 않습니다.", HttpStatus.BAD_REQUEST, null),
     PAYMENT_AMOUNT_MISMATCH("PAYMENT_AMOUNT_MISMATCH","PG 승인 금액이 일치하지 않습니다.", HttpStatus.BAD_REQUEST, null),
-    PAYMENT_CONFIRM_UNKNOWN("PAYMENT_CONFIRM_UNKNOWN","결제 승인 결과를 확인할 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR, null);
+    PAYMENT_CONFIRM_UNKNOWN("PAYMENT_CONFIRM_UNKNOWN","결제 승인 결과를 확인할 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR, null),
+    FAILE_POINT_TO_WALLET("FAILE_POINT_TO_WALLET","충전 포인트 반영에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, null);
 
     private final String code;
     private final String field;

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/domain/exception/PaymentErrorCode.java
@@ -11,7 +11,7 @@ public enum PaymentErrorCode implements ErrorCodeSpec {
     INVALID_PAYMENT_KEY("INVALID_PAYMENT_KEY", "결제키가 유효하지 않습니다.", HttpStatus.BAD_REQUEST, null),
     PAYMENT_AMOUNT_MISMATCH("PAYMENT_AMOUNT_MISMATCH","PG 승인 금액이 일치하지 않습니다.", HttpStatus.BAD_REQUEST, null),
     PAYMENT_CONFIRM_UNKNOWN("PAYMENT_CONFIRM_UNKNOWN","결제 승인 결과를 확인할 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR, null),
-    FAILE_POINT_TO_WALLET("FAILE_POINT_TO_WALLET","충전 포인트 반영에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, null);
+    FAILED_POINT_TO_WALLET("FAILED_POINT_TO_WALLET","충전 포인트 반영에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR, null);
 
     private final String code;
     private final String field;

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/toss/TossPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/toss/TossPaymentAdapter.java
@@ -2,7 +2,6 @@ package com.trustamarket.paymentservice.paymentservice.infrastructure.toss;
 
 import com.trustamarket.paymentservice.paymentservice.application.dto.result.TossConfirmResult;
 import com.trustamarket.paymentservice.paymentservice.application.port.TossPaymentPort;
-import com.trustamarket.paymentservice.paymentservice.domain.entity.Payment;
 import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentErrorCode;
 import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentException;
 import com.trustamarket.paymentservice.paymentservice.infrastructure.toss.dto.TossConfirmRequest;

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/WalletAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/WalletAdapter.java
@@ -20,7 +20,8 @@ public class WalletAdapter implements WalletPort {
                 paymentId, chargedAmount
         );
 
-        UUID userId = UUID.randomUUID(); // 임시 userId전달
+        //// 임시 userId전달 추후에 헤더값의 uerId로 변경
+        UUID userId = UUID.randomUUID();
         return walletFeignClient.pointToWallet(userId, request);
     }
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/WalletAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/WalletAdapter.java
@@ -1,5 +1,6 @@
 package com.trustamarket.paymentservice.paymentservice.infrastructure.wallet;
 
+import com.trustamarket.common.response.CommonResponse;
 import com.trustamarket.paymentservice.paymentservice.application.port.WalletPort;
 import com.trustamarket.paymentservice.paymentservice.infrastructure.wallet.dto.PointWalletRequest;
 import lombok.RequiredArgsConstructor;
@@ -14,12 +15,12 @@ public class WalletAdapter implements WalletPort {
     private final WalletFeignClient walletFeignClient;
 
     @Override
-    public void pointToWallet(UUID paymentId, long chargedAmount){
+    public CommonResponse<Void> pointToWallet(UUID paymentId, long chargedAmount){
         PointWalletRequest request = new PointWalletRequest(
                 paymentId, chargedAmount
         );
 
         UUID userId = UUID.randomUUID(); // 임시 userId전달
-        walletFeignClient.pointToWallet(userId, request);
+        return walletFeignClient.pointToWallet(userId, request);
     }
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/WalletAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/WalletAdapter.java
@@ -1,0 +1,25 @@
+package com.trustamarket.paymentservice.paymentservice.infrastructure.wallet;
+
+import com.trustamarket.paymentservice.paymentservice.application.port.WalletPort;
+import com.trustamarket.paymentservice.paymentservice.infrastructure.wallet.dto.PointWalletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class WalletAdapter implements WalletPort {
+
+    private final WalletFeignClient walletFeignClient;
+
+    @Override
+    public void pointToWallet(UUID paymentId, long chargedAmount){
+        PointWalletRequest request = new PointWalletRequest(
+                paymentId, chargedAmount
+        );
+
+        UUID userId = UUID.randomUUID(); // 임시 userId전달
+        walletFeignClient.pointToWallet(userId, request);
+    }
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/WalletFeignClient.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/WalletFeignClient.java
@@ -1,5 +1,6 @@
 package com.trustamarket.paymentservice.paymentservice.infrastructure.wallet;
 
+import com.trustamarket.common.response.CommonResponse;
 import com.trustamarket.paymentservice.paymentservice.infrastructure.wallet.dto.PointWalletRequest;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,7 +13,7 @@ import java.util.UUID;
 public interface WalletFeignClient {
 
     @PostMapping("/internal/wallets/{userId}/charge")
-    void pointToWallet(
+    CommonResponse<Void> pointToWallet(
             @PathVariable UUID userId,
             @RequestBody PointWalletRequest request
     );

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/WalletFeignClient.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/WalletFeignClient.java
@@ -1,0 +1,19 @@
+package com.trustamarket.paymentservice.paymentservice.infrastructure.wallet;
+
+import com.trustamarket.paymentservice.paymentservice.infrastructure.wallet.dto.PointWalletRequest;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.UUID;
+
+@FeignClient(name="wallet-service")
+public interface WalletFeignClient {
+
+    @PostMapping("/internal/wallets/{userId}/charge")
+    void pointToWallet(
+            @PathVariable UUID userId,
+            @RequestBody PointWalletRequest request
+    );
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/dto/PointWalletRequest.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/dto/PointWalletRequest.java
@@ -1,8 +1,21 @@
 package com.trustamarket.paymentservice.paymentservice.infrastructure.wallet.dto;
 
+import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentErrorCode;
+import com.trustamarket.paymentservice.paymentservice.domain.exception.PaymentException;
+
 import java.util.UUID;
 
 public record PointWalletRequest (
     UUID paymentId,
     long chargedAmount
-){}
+){
+    public PointWalletRequest {
+        if(paymentId == null) {
+            throw new PaymentException(PaymentErrorCode.INVALID_PAYMENT_KEY);
+        }
+        if(chargedAmount <= 0) {
+            //todo : long -> Amount
+            throw new IllegalArgumentException("결제 금액은 0보다 커야 합니다.");
+        }
+    }
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/dto/PointWalletRequest.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/dto/PointWalletRequest.java
@@ -11,7 +11,7 @@ public record PointWalletRequest (
 ){
     public PointWalletRequest {
         if(paymentId == null) {
-            throw new PaymentException(PaymentErrorCode.INVALID_PAYMENT_KEY);
+            throw new IllegalArgumentException("paymentId는 필수값입니다.");
         }
         if(chargedAmount <= 0) {
             //todo : long -> Amount

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/dto/PointWalletRequest.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/infrastructure/wallet/dto/PointWalletRequest.java
@@ -1,0 +1,8 @@
+package com.trustamarket.paymentservice.paymentservice.infrastructure.wallet.dto;
+
+import java.util.UUID;
+
+public record PointWalletRequest (
+    UUID paymentId,
+    long chargedAmount
+){}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/DemoPaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/DemoPaymentController.java
@@ -11,14 +11,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import java.util.UUID;
 
 @Controller
-@RequestMapping("/demo/payments")
+@RequestMapping("/demo/v1/payments")
 @RequiredArgsConstructor
 public class DemoPaymentController {
 
-    @Value("${TOSS_CLIENT_KEY}")
+    @Value("${toss.payment.client-key}")
     private String tossClientKey;
 
-    @Value("${TOSS_CUSTOMER_KEY}")
+    @Value("${toss.payment.customer-key}")
     private String tossCustomerKey;
 
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/DemoPaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/DemoPaymentController.java
@@ -19,11 +19,7 @@ public class DemoPaymentController {
     private final PaymentUseCase paymentUseCase;
 
     @GetMapping("/checkout")
-    public String checkout(@RequestParam long amount,
-                           @RequestParam UUID paymentId,
-                           Model model) {
-        model.addAttribute("amount", amount);
-        model.addAttribute("paymentId", paymentId);
+    public String checkout(){
         return "checkout";
     }
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/DemoPaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/DemoPaymentController.java
@@ -16,8 +16,6 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class DemoPaymentController {
 
-    private final PaymentUseCase paymentUseCase;
-
     @GetMapping("/checkout")
     public String checkout(){
         return "checkout";

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/DemoPaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/DemoPaymentController.java
@@ -1,13 +1,12 @@
 package com.trustamarket.paymentservice.paymentservice.presentation;
 
-import com.trustamarket.paymentservice.paymentservice.application.port.PaymentUseCase;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.UUID;
 
@@ -16,8 +15,17 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class DemoPaymentController {
 
+    @Value("${toss.client-key}")
+    private String tossClientKey;
+
+    @Value("${toss.customer-key}")
+    private String tossCustomerKey;
+
+
     @GetMapping("/checkout")
-    public String checkout(){
+    public String checkout(Model model){
+        model.addAttribute("toss_Client_Key", tossClientKey);
+        model.addAttribute("toss_Customer_Key", tossCustomerKey);
         return "checkout";
     }
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/DemoPaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/DemoPaymentController.java
@@ -15,17 +15,17 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class DemoPaymentController {
 
-    @Value("${toss.client-key}")
+    @Value("${TOSS_CLIENT_KEY}")
     private String tossClientKey;
 
-    @Value("${toss.customer-key}")
+    @Value("${TOSS_CUSTOMER_KEY}")
     private String tossCustomerKey;
 
 
     @GetMapping("/checkout")
     public String checkout(Model model){
-        model.addAttribute("toss_Client_Key", tossClientKey);
-        model.addAttribute("toss_Customer_Key", tossCustomerKey);
+        model.addAttribute("TOSS_CLIENT_KEY", tossClientKey);
+        model.addAttribute("TOSS_CUSTOMER_KEY", tossCustomerKey);
         return "checkout";
     }
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/presentation/PaymentController.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/payments")
+@RequestMapping("/api/v1/payments")
 @RequiredArgsConstructor
 public class PaymentController {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,5 @@ toss:
   payment:
     base-url: https://api.tosspayments.com
     secret-key: ${TOSS_SECRET_KEY}
+    client-key: ${TOSS_CLIENT_KEY}
+    customer-key: ${TOSS_CUSTOMER_KEY}

--- a/src/main/resources/templates/checkout.html
+++ b/src/main/resources/templates/checkout.html
@@ -31,7 +31,7 @@
     <button class="button" onclick="requestPayment()">결제하기</button>
   </div>
 
-    <script>
+    <script th:inline="javascript">
       const clientKey = /*[[${toss_Client_Key}]]*/ "";
       const customerKey = /*[[${toss_Customer_Key}]]*/ "";
 

--- a/src/main/resources/templates/checkout.html
+++ b/src/main/resources/templates/checkout.html
@@ -32,8 +32,8 @@
   </div>
 
     <script th:inline="javascript">
-      const clientKey = /*[[${toss_Client_Key}]]*/ "";
-      const customerKey = /*[[${toss_Customer_Key}]]*/ "";
+      const clientKey = /*[[${TOSS_CLIENT_KEY}]]*/ "";
+      const customerKey = /*[[${TOSS_CUSTOMER_KEY}]]*/ "";
 
       const tossPayments = TossPayments(clientKey);
       const payment = tossPayments.payment({ customerKey });

--- a/src/main/resources/templates/checkout.html
+++ b/src/main/resources/templates/checkout.html
@@ -9,9 +9,9 @@
 <body>
   <div style="margin-top: 30px">
     <div>
-      <label for="orderId">orderId</label>
+      <label for="chargeId">chargeId</label>
       <input
-              id="orderId"
+              id="chargeId"
               type="text"
               readonly
               style="display: block; margin: 8px 0 16px; padding: 8px; width: 300px;"
@@ -40,19 +40,19 @@
 
       window.onload = () => {
         const uuid = crypto.randomUUID();
-        document.getElementById("orderId").value = uuid;
+        document.getElementById("chargeId").value = uuid;
       };
 
       async function requestPayment() {
-        const orderIdInput = document.getElementById("orderId").value.trim();
+        const chargeIdInput = document.getElementById("chargeId").value.trim();
         const amountInput = Number(document.getElementById("amount").value);
 
-        if (!orderIdInput) {
-          alert("orderId를 입력해주세요.");
+        if (!chargeIdInput) {
+          alert("chargeId를 입력해주세요.");
           return;
         }
 
-        if (!amountInput || amountInput <= 0) {
+        if (!Number.isInteger(amountInput) || amountInput <= 0) {
           alert("amount는 1원 이상이어야 합니다.");
           return;
         }
@@ -64,7 +64,7 @@
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            chargeId: orderIdInput,
+            chargeId: chargeIdInput,
             amount: amountInput,
           }),
         });

--- a/src/main/resources/templates/checkout.html
+++ b/src/main/resources/templates/checkout.html
@@ -32,8 +32,8 @@
   </div>
 
     <script>
-      const clientKey = "test_ck_EP59LybZ8BDo7yajD4LYV6GYo7pR";
-      const customerKey = "aFNXGirOcx1ZjKalfy5K_";
+      const clientKey = /*[[${toss_Client_Key}]]*/ "";
+      const customerKey = /*[[${toss_Customer_Key}]]*/ "";
 
       const tossPayments = TossPayments(clientKey);
       const payment = tossPayments.payment({ customerKey });

--- a/src/main/resources/templates/checkout.html
+++ b/src/main/resources/templates/checkout.html
@@ -5,41 +5,116 @@
   <link rel="stylesheet" type="text/css" href="/css/style.css" />
   <script src="https://js.tosspayments.com/v2/standard"></script>
 </head>
+
 <body>
-<button class="button" style="margin-top: 30px" onclick="requestPayment()">결제하기</button>
+  <div style="margin-top: 30px">
+    <div>
+      <label for="orderId">orderId</label>
+      <input
+              id="orderId"
+              type="text"
+              readonly
+              style="display: block; margin: 8px 0 16px; padding: 8px; width: 300px;"
+      />
+    </div>
 
-<script>
-  const urlParams = new URLSearchParams(window.location.search);
-  const amount = Number(urlParams.get("amount"));
-  const paymentId = urlParams.get("paymentId");
+    <div>
+      <label for="amount">amount</label>
+      <input
+              id="amount"
+              type="number"
+              placeholder="금액을 입력하세요"
+              style="display: block; margin: 8px 0 16px; padding: 8px; width: 300px;"
+      />
+    </div>
 
-  const clientKey = "test_ck_EP59LybZ8BDo7yajD4LYV6GYo7pR";
-  const customerKey = "aFNXGirOcx1ZjKalfy5K_";
-  const tossPayments = TossPayments(clientKey);
-  const payment = tossPayments.payment({ customerKey });
+    <button class="button" onclick="requestPayment()">결제하기</button>
+  </div>
 
-  async function requestPayment() {
-    await payment.requestPayment({
-      method: "CARD",
-      amount: {
-        currency: "KRW",
-        value: amount,
-      },
-      orderId: paymentId,
-      orderName: "포인트 충전",
-      successUrl: window.location.origin + "/demo/payments/" + paymentId + "/success",
-      failUrl: window.location.origin + "/demo/payments/" + paymentId + "/failure",
-      customerEmail: "customer123@gmail.com",
-      customerName: "김토스",
-      customerMobilePhone: "01012341234",
-      card: {
-        useEscrow: false,
-        flowMode: "DEFAULT",
-        useCardPoint: false,
-        useAppCardOnly: false,
-      },
-    });
-  }
-</script>
-</body>
+    <script>
+      const clientKey = "test_ck_EP59LybZ8BDo7yajD4LYV6GYo7pR";
+      const customerKey = "aFNXGirOcx1ZjKalfy5K_";
+
+      const tossPayments = TossPayments(clientKey);
+      const payment = tossPayments.payment({ customerKey });
+
+      window.onload = () => {
+        const uuid = crypto.randomUUID();
+        document.getElementById("orderId").value = uuid;
+      };
+
+      async function requestPayment() {
+        const orderIdInput = document.getElementById("orderId").value.trim();
+        const amountInput = Number(document.getElementById("amount").value);
+
+        if (!orderIdInput) {
+          alert("orderId를 입력해주세요.");
+          return;
+        }
+
+        if (!amountInput || amountInput <= 0) {
+          alert("amount는 1원 이상이어야 합니다.");
+          return;
+        }
+
+        // 1. 서버에 결제 생성 요청
+        const response = await fetch("/api/payments", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            chargeId: orderIdInput,
+            amount: amountInput,
+          }),
+        });
+
+        if (!response.ok) {
+          alert("결제 생성 실패");
+          return;
+        }
+
+        const result = await response.json();
+        const createdPayment = result.data;
+
+        // 서버에서 생성된 paymentId 사용
+        const paymentId = createdPayment.paymentId;
+        const paymentAmount = createdPayment.amount;
+
+        // 2. Toss 결제창 호출
+        await payment.requestPayment({
+          method: "CARD",
+          amount: {
+            currency: "KRW",
+            value: paymentAmount,
+          },
+          orderId: paymentId,
+          orderName: "포인트 충전",
+
+          successUrl:
+                  window.location.origin +
+                  "/demo/payments/" +
+                  paymentId +
+                  "/success",
+
+          failUrl:
+                  window.location.origin +
+                  "/demo/payments/" +
+                  paymentId +
+                  "/failure",
+
+          customerEmail: "customer123@gmail.com",
+          customerName: "김토스",
+          customerMobilePhone: "01012341234",
+
+          card: {
+            useEscrow: false,
+            flowMode: "DEFAULT",
+            useCardPoint: false,
+            useAppCardOnly: false,
+          },
+        });
+      }
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## 🌱 설명

- 충전 결제 완료 후 Wallet에 충전값 전달 기능 구현
- 프론트에서 결제 요청시 초기 테이블 생성 추가

## 📌 관련 이슈

close #12 

## ✅ 주요 변경 사항

- (demo/payments/checkout) 사용으로 결제 로직 시연가능
- 결제 완료시 포인트 지갑에 반영로직

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

이후에 랜덤값으로 보내는 userId를 Gateway에서 전달되는 헤더값으로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 결제 완료 시 지갑으로 포인트 자동 적립 연동 추가
  * 체크아웃 UI 개선: 주문 ID(chargeId) 자동 생성, 사용자가 금액 입력, 서버에 결제 생성 요청 후 반환된 값으로 결제 수행
  * 결제 제공자 키를 서버 설정에서 주입하도록 변경하고 클라이언트에서 유효성 검사 및 서버 POST 흐름 도입

* **버그 수정**
  * 포인트 적립 호출 실패 시 예외를 로깅하고 결제 성공 처리는 유지하도록 처리(재시도/복구는 TODO)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->