### PR TITLE
[refactor] 테스트를 위한 mock 추가

### DIFF
--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/application/service/PaymentService.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/application/service/PaymentService.java
@@ -53,11 +53,12 @@ public class PaymentService implements PaymentUseCase {
 
     @Override
     @Transactional
+    //결제창 성공
     public SucceededPaymentResult succeededPayment(SucceededPaymentCommand command) {
         Payment payment = paymentRepository.findById(command.paymentId());
         payment.validateConfirm(command.paymentKey(), command.amount());
 
-        try {
+        try { //결제승인 성공
             tossPaymentPort.confirm(
                     command.paymentKey(),
                     command.paymentId(),
@@ -68,15 +69,11 @@ public class PaymentService implements PaymentUseCase {
             SucceededPaymentResult frontResult = SucceededPaymentResult.from(payment);
             PaymentResponseResult result = PaymentResponseResult.from(payment);
 
-            try {
-                walletPort.pointToWallet(result);
-            } catch (Exception e){
-                // todo : 포인트 적립 실패 로직
-            }
-
+            walletPort.pointToWallet(result);
             return frontResult;
 
         } catch (PaymentException e) {
+            //결제승인 실패
             FailPaymentCommand failCommand = new FailPaymentCommand(
                     command.paymentId(),
                     "CONFIRM_FAIL",
@@ -89,6 +86,7 @@ public class PaymentService implements PaymentUseCase {
 
     @Override
     @Transactional
+    //결제창 실패
     public FailPaymentResult failPayment(FailPaymentCommand command) {
         Payment payment = paymentRepository.findById(command.paymentId());
 
@@ -96,6 +94,7 @@ public class PaymentService implements PaymentUseCase {
 
         FailPaymentResult result = FailPaymentResult.from(payment);
         walletPort.pointToWallet(PaymentResponseResult.from(payment));
+
         return result;
     }
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/application/service/PaymentService.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/application/service/PaymentService.java
@@ -57,22 +57,34 @@ public class PaymentService implements PaymentUseCase {
         Payment payment = paymentRepository.findById(command.paymentId());
         payment.validateConfirm(command.paymentKey(), command.amount());
 
-        tossPaymentPort.confirm(
-                command.paymentKey(),
-                payment.getPaymentId(),
-                command.amount()
-        );
-
-        payment.successPayment(command.paymentKey(), command.amount());
-        SucceededPaymentResult frontResult = SucceededPaymentResult.from(payment);
-        PaymentResponseResult result = PaymentResponseResult.from(payment);
-
         try {
-            walletPort.pointToWallet(result);
-        } catch (Exception e){
-            // todo : 포인트 적립 실패 로직
+            tossPaymentPort.confirm(
+                    command.paymentKey(),
+                    command.paymentId(),
+                    command.amount()
+            );
+
+            payment.successPayment(command.paymentKey(), command.amount());
+            SucceededPaymentResult frontResult = SucceededPaymentResult.from(payment);
+            PaymentResponseResult result = PaymentResponseResult.from(payment);
+
+            try {
+                walletPort.pointToWallet(result);
+            } catch (Exception e){
+                // todo : 포인트 적립 실패 로직
+            }
+
+            return frontResult;
+
+        } catch (PaymentException e) {
+            FailPaymentCommand failCommand = new FailPaymentCommand(
+                    command.paymentId(),
+                    "CONFIRM_FAIL",
+                    e.getMessage()
+            );
+            failPayment(failCommand);
+            throw e;
         }
-        return frontResult;
     }
 
     @Override
@@ -83,6 +95,7 @@ public class PaymentService implements PaymentUseCase {
         payment.failPayment(command.code(), command.message());
 
         FailPaymentResult result = FailPaymentResult.from(payment);
+        walletPort.pointToWallet(PaymentResponseResult.from(payment));
         return result;
     }
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/application/service/PaymentService.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/application/service/PaymentService.java
@@ -20,7 +20,6 @@ import com.trustamarket.paymentservice.paymentservice.payment.domain.exception.P
 import com.trustamarket.paymentservice.paymentservice.payment.domain.exception.PaymentException;
 import com.trustamarket.paymentservice.paymentservice.payment.domain.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -30,7 +29,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.UUID;
 
 @Service
-@Slf4j
 @RequiredArgsConstructor
 public class PaymentService implements PaymentUseCase {
 
@@ -72,10 +70,8 @@ public class PaymentService implements PaymentUseCase {
         try {
             walletPort.pointToWallet(result);
         } catch (Exception e){
-            log.error("포인트 적립 실패", e);
             // todo : 포인트 적립 실패 로직
         }
-
         return frontResult;
     }
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
@@ -2,6 +2,8 @@ package com.trustamarket.paymentservice.paymentservice.payment.infrastructure.to
 
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.TossConfirmResult;
 import com.trustamarket.paymentservice.paymentservice.payment.application.port.TossPaymentPort;
+import com.trustamarket.paymentservice.paymentservice.payment.domain.exception.PaymentErrorCode;
+import com.trustamarket.paymentservice.paymentservice.payment.domain.exception.PaymentException;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -13,6 +15,10 @@ public class MockTossPaymentAdapter implements TossPaymentPort {
 
     @Override
     public TossConfirmResult confirm(String paymentKey, UUID paymentId, long amount) {
+
+        if(amount <= 0 ){
+            throw new PaymentException(PaymentErrorCode.INVALID_PAYMENT_AMOUNT);
+        }
         return new TossConfirmResult(
                 paymentKey,
                 paymentId.toString(),

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
@@ -21,6 +21,7 @@ public class MockTossPaymentAdapter implements TossPaymentPort {
         }
 
         //처리 시간 시뮬레이션 2초
+        //결제 승인보다는 결제창에서 실패 확률이 더 높지만 편의성을 위해 confirm으로 실패 테스트 진행
         try {
             Thread.sleep(2000);
         } catch (InterruptedException e) {

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
@@ -1,12 +1,9 @@
 package com.trustamarket.paymentservice.paymentservice.payment.infrastructure.toss;
 
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.TossConfirmResult;
-import com.trustamarket.paymentservice.paymentservice.payment.application.port.PaymentUseCase;
 import com.trustamarket.paymentservice.paymentservice.payment.application.port.TossPaymentPort;
 import com.trustamarket.paymentservice.paymentservice.payment.domain.exception.PaymentErrorCode;
 import com.trustamarket.paymentservice.paymentservice.payment.domain.exception.PaymentException;
-import com.trustamarket.paymentservice.paymentservice.payout.infrastructure.user.UserFeignClient;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -14,11 +11,7 @@ import java.util.UUID;
 
 @Component
 @Profile("mocktest")
-@RequiredArgsConstructor
 public class MockTossPaymentAdapter implements TossPaymentPort {
-
-    private final PaymentUseCase paymentUseCase;
-    private final UserFeignClient userFeignClient;
 
     @Override
     public TossConfirmResult confirm(String paymentKey, UUID paymentId, long amount) {

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
@@ -1,0 +1,22 @@
+package com.trustamarket.paymentservice.paymentservice.payment.infrastructure.toss;
+
+import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.TossConfirmResult;
+import com.trustamarket.paymentservice.paymentservice.payment.application.port.TossPaymentPort;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@Profile("mocktest")
+public class MockTossPaymentAdapter implements TossPaymentPort {
+
+    @Override
+    public TossConfirmResult confirm(String paymentKey, UUID paymentId, long amount) {
+        return new TossConfirmResult(
+                paymentKey,
+                paymentId.toString(),
+                amount
+        );
+    }
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
@@ -25,6 +25,7 @@ public class MockTossPaymentAdapter implements TossPaymentPort {
             Thread.sleep(2000);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIRM_UNKNOWN);
         }
 
         //승인실패 5%

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
@@ -1,9 +1,12 @@
 package com.trustamarket.paymentservice.paymentservice.payment.infrastructure.toss;
 
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.TossConfirmResult;
+import com.trustamarket.paymentservice.paymentservice.payment.application.port.PaymentUseCase;
 import com.trustamarket.paymentservice.paymentservice.payment.application.port.TossPaymentPort;
 import com.trustamarket.paymentservice.paymentservice.payment.domain.exception.PaymentErrorCode;
 import com.trustamarket.paymentservice.paymentservice.payment.domain.exception.PaymentException;
+import com.trustamarket.paymentservice.paymentservice.payout.infrastructure.user.UserFeignClient;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +14,11 @@ import java.util.UUID;
 
 @Component
 @Profile("mocktest")
+@RequiredArgsConstructor
 public class MockTossPaymentAdapter implements TossPaymentPort {
+
+    private final PaymentUseCase paymentUseCase;
+    private final UserFeignClient userFeignClient;
 
     @Override
     public TossConfirmResult confirm(String paymentKey, UUID paymentId, long amount) {
@@ -25,6 +32,11 @@ public class MockTossPaymentAdapter implements TossPaymentPort {
             Thread.sleep(2000);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+        }
+
+        //승인실패 5%
+        if (Math.random() <= 0.05) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIRM_UNKNOWN);
         }
 
         return new TossConfirmResult(

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/MockTossPaymentAdapter.java
@@ -19,6 +19,14 @@ public class MockTossPaymentAdapter implements TossPaymentPort {
         if(amount <= 0 ){
             throw new PaymentException(PaymentErrorCode.INVALID_PAYMENT_AMOUNT);
         }
+
+        //처리 시간 시뮬레이션 2초
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
         return new TossConfirmResult(
                 paymentKey,
                 paymentId.toString(),

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/TossPaymentAdapter.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/infrastructure/toss/TossPaymentAdapter.java
@@ -8,11 +8,13 @@ import com.trustamarket.paymentservice.paymentservice.payment.infrastructure.tos
 import com.trustamarket.paymentservice.paymentservice.payment.infrastructure.toss.dto.TossConfirmResponse;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
 
 @Component
+@Profile("!mocktest")
 @RequiredArgsConstructor
 public class TossPaymentAdapter implements TossPaymentPort {
 

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/presentation/PaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/presentation/PaymentController.java
@@ -9,7 +9,6 @@ import com.trustamarket.paymentservice.paymentservice.payment.application.dto.qu
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.query.PaymentSearchQuery;
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.FailPaymentResult;
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.PaymentDetailResult;
-import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.PaymentInfoResult;
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.SearchPaymentResult;
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.SucceededPaymentResult;
 import com.trustamarket.paymentservice.paymentservice.payment.application.port.PaymentUseCase;
@@ -22,7 +21,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
@@ -30,7 +28,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -69,40 +66,6 @@ public class PaymentController {
         FailPaymentResponse response = FailPaymentResponse.from(result);
 
         return new CommonResponse<>(HttpStatus.OK.value(), response);
-    }
-
-    //테스트 목적
-    @Profile("mocktest")
-    @PostMapping("/{paymentId}/test")
-    public CommonResponse<?> testPayment(@PathVariable UUID paymentId){
-        boolean success = Math.random() > 0.05;
-
-        if (success) {
-            PaymentInfoResult info = paymentUseCase.getPaymentInfo(paymentId);
-            SucceededPaymentCommand command = new SucceededPaymentCommand(
-                    paymentId,
-                    "mock-payment-key-" + paymentId,
-                    info.amount()
-            );
-
-            SucceededPaymentResult result = paymentUseCase.succeededPayment(command);
-            return new CommonResponse<>(
-                    HttpStatus.OK.value(),
-                    SucceededPaymentResponse.from(result)
-            );
-        }
-
-        FailPaymentCommand command = new FailPaymentCommand(
-                paymentId,
-                "MOCK_PAYMENT_FAILED",
-                "부하테스트용 mock 결제 실패"
-        );
-
-        FailPaymentResult result = paymentUseCase.failPayment(command);
-        return new CommonResponse<>(
-                HttpStatus.OK.value(),
-                FailPaymentResponse.from(result)
-        );
     }
 
     @PreAuthorize("hasRole('MEMBER')")

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/presentation/PaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/presentation/PaymentController.java
@@ -22,6 +22,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
@@ -71,6 +72,7 @@ public class PaymentController {
     }
 
     //테스트 목적
+    @Profile("mocktest")
     @PostMapping("/{paymentId}/test")
     public CommonResponse<?> testPayment(@PathVariable UUID paymentId){
         boolean success = Math.random() > 0.05;

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/presentation/PaymentController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/presentation/PaymentController.java
@@ -9,6 +9,7 @@ import com.trustamarket.paymentservice.paymentservice.payment.application.dto.qu
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.query.PaymentSearchQuery;
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.FailPaymentResult;
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.PaymentDetailResult;
+import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.PaymentInfoResult;
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.SearchPaymentResult;
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.SucceededPaymentResult;
 import com.trustamarket.paymentservice.paymentservice.payment.application.port.PaymentUseCase;
@@ -28,6 +29,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -66,6 +68,39 @@ public class PaymentController {
         FailPaymentResponse response = FailPaymentResponse.from(result);
 
         return new CommonResponse<>(HttpStatus.OK.value(), response);
+    }
+
+    //테스트 목적
+    @PostMapping("/{paymentId}/test")
+    public CommonResponse<?> testPayment(@PathVariable UUID paymentId){
+        boolean success = Math.random() > 0.05;
+
+        if (success) {
+            PaymentInfoResult info = paymentUseCase.getPaymentInfo(paymentId);
+            SucceededPaymentCommand command = new SucceededPaymentCommand(
+                    paymentId,
+                    "mock-payment-key-" + paymentId,
+                    info.amount()
+            );
+
+            SucceededPaymentResult result = paymentUseCase.succeededPayment(command);
+            return new CommonResponse<>(
+                    HttpStatus.OK.value(),
+                    SucceededPaymentResponse.from(result)
+            );
+        }
+
+        FailPaymentCommand command = new FailPaymentCommand(
+                paymentId,
+                "MOCK_PAYMENT_FAILED",
+                "부하테스트용 mock 결제 실패"
+        );
+
+        FailPaymentResult result = paymentUseCase.failPayment(command);
+        return new CommonResponse<>(
+                HttpStatus.OK.value(),
+                FailPaymentResponse.from(result)
+        );
     }
 
     @PreAuthorize("hasRole('MEMBER')")

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/presentation/PaymentTestController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/presentation/PaymentTestController.java
@@ -1,13 +1,10 @@
 package com.trustamarket.paymentservice.paymentservice.payment.presentation;
 
 import com.trustamarket.common.response.CommonResponse;
-import com.trustamarket.paymentservice.paymentservice.payment.application.dto.command.FailPaymentCommand;
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.command.SucceededPaymentCommand;
-import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.FailPaymentResult;
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.PaymentInfoResult;
 import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.SucceededPaymentResult;
 import com.trustamarket.paymentservice.paymentservice.payment.application.port.PaymentUseCase;
-import com.trustamarket.paymentservice.paymentservice.payment.presentation.dto.response.FailPaymentResponse;
 import com.trustamarket.paymentservice.paymentservice.payment.presentation.dto.response.SucceededPaymentResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
@@ -28,35 +25,19 @@ public class PaymentTestController {
     private final PaymentUseCase paymentUseCase;
 
     @PostMapping("/{paymentId}/test")
-    public CommonResponse<?> testPayment(@PathVariable UUID paymentId){
-        boolean success = Math.random() > 0.05;
+    public CommonResponse<SucceededPaymentResponse> testPayment(@PathVariable UUID paymentId){
 
-        if (success) {
-            PaymentInfoResult info = paymentUseCase.getPaymentInfo(paymentId);
-            SucceededPaymentCommand command = new SucceededPaymentCommand(
-                    paymentId,
-                    "mock-payment-key-" + paymentId,
-                    info.amount()
-            );
-
-            SucceededPaymentResult result = paymentUseCase.succeededPayment(command);
-            return new CommonResponse<>(
-                    HttpStatus.OK.value(),
-                    SucceededPaymentResponse.from(result)
-            );
-        }
-
-        FailPaymentCommand command = new FailPaymentCommand(
+        PaymentInfoResult info = paymentUseCase.getPaymentInfo(paymentId);
+        SucceededPaymentCommand command = new SucceededPaymentCommand(
                 paymentId,
-                "MOCK_PAYMENT_FAILED",
-                "부하테스트용 mock 결제 실패"
+                "mock-payment-key-" + paymentId,
+                info.amount()
         );
 
-        FailPaymentResult result = paymentUseCase.failPayment(command);
+        SucceededPaymentResult result = paymentUseCase.succeededPayment(command);
         return new CommonResponse<>(
                 HttpStatus.OK.value(),
-                FailPaymentResponse.from(result)
+                SucceededPaymentResponse.from(result)
         );
     }
-
 }

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/presentation/PaymentTestController.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payment/presentation/PaymentTestController.java
@@ -1,0 +1,62 @@
+package com.trustamarket.paymentservice.paymentservice.payment.presentation;
+
+import com.trustamarket.common.response.CommonResponse;
+import com.trustamarket.paymentservice.paymentservice.payment.application.dto.command.FailPaymentCommand;
+import com.trustamarket.paymentservice.paymentservice.payment.application.dto.command.SucceededPaymentCommand;
+import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.FailPaymentResult;
+import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.PaymentInfoResult;
+import com.trustamarket.paymentservice.paymentservice.payment.application.dto.result.SucceededPaymentResult;
+import com.trustamarket.paymentservice.paymentservice.payment.application.port.PaymentUseCase;
+import com.trustamarket.paymentservice.paymentservice.payment.presentation.dto.response.FailPaymentResponse;
+import com.trustamarket.paymentservice.paymentservice.payment.presentation.dto.response.SucceededPaymentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@Profile("mocktest")
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+public class PaymentTestController {
+
+    private final PaymentUseCase paymentUseCase;
+
+    @PostMapping("/{paymentId}/test")
+    public CommonResponse<?> testPayment(@PathVariable UUID paymentId){
+        boolean success = Math.random() > 0.05;
+
+        if (success) {
+            PaymentInfoResult info = paymentUseCase.getPaymentInfo(paymentId);
+            SucceededPaymentCommand command = new SucceededPaymentCommand(
+                    paymentId,
+                    "mock-payment-key-" + paymentId,
+                    info.amount()
+            );
+
+            SucceededPaymentResult result = paymentUseCase.succeededPayment(command);
+            return new CommonResponse<>(
+                    HttpStatus.OK.value(),
+                    SucceededPaymentResponse.from(result)
+            );
+        }
+
+        FailPaymentCommand command = new FailPaymentCommand(
+                paymentId,
+                "MOCK_PAYMENT_FAILED",
+                "부하테스트용 mock 결제 실패"
+        );
+
+        FailPaymentResult result = paymentUseCase.failPayment(command);
+        return new CommonResponse<>(
+                HttpStatus.OK.value(),
+                FailPaymentResponse.from(result)
+        );
+    }
+
+}

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payout/infrastructure/pgMock/PgMockClient.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payout/infrastructure/pgMock/PgMockClient.java
@@ -1,12 +1,14 @@
 package com.trustamarket.paymentservice.paymentservice.payout.infrastructure.pgMock;
 
-import com.trustamarket.paymentservice.paymentservice.payout.application.port.out.pgClient.PgPayoutRequest;
 import com.trustamarket.paymentservice.paymentservice.payout.application.port.out.pgClient.PgClientPort;
+import com.trustamarket.paymentservice.paymentservice.payout.application.port.out.pgClient.PgPayoutRequest;
 import com.trustamarket.paymentservice.paymentservice.payout.application.port.out.pgClient.PgPayoutResult;
 import com.trustamarket.paymentservice.paymentservice.payout.domain.enums.PayoutStatus;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
+@Profile("mocktest")
 public class PgMockClient implements PgClientPort {
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: payment-service
+  profiles:
+    active: mocktest
   config:
     import: "optional:configserver:http://localhost:8888"
 


### PR DESCRIPTION
## 🌱 설명

테스트를 위해 mock api, adapter 추가했습니다.

## 📌 관련 이슈

close #27

## ✅ 주요 변경 사항

- 테스트용 api (/api/v1/payments/{paymentId}/test)
- mock 결제 요청 시 성공으로 처리 
   (결제창이 승인보다 오류 확률이 높지만 테스트 편의를 위해 confirm에서 5%확률로 실패 테스트 진행, 추후에 재시도로직 추가 계정)
- MockTossPaymentAdapter 추가 -> profile : mocktest 에서 활성화

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.
 
- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 모의 테스트용 결제 엔드포인트 추가: POST /api/v1/payments/{paymentId}/test로 모의 결제 시나리오 실행 가능.

* **Chores**
  * mocktest 프로파일 기반으로 모의 결제 및 페이아웃 구현체 활성화 지원 추가.

* **Behavior Change**
  * 결제 실패 처리 시 지갑 포인트 연동 동작이 추가되어 포인트 상태에 영향이 있을 수 있음.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/payment-service/pull/28)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->