### PR TITLE
fix: K8s 프로필 PgClientPort NoOp 빈 추가

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -62,11 +62,11 @@ spec:
                   key: TOSS_CUSTOMER_KEY
           resources:
             requests:
-              cpu: 500m
-              memory: 1Gi
+              cpu: 700m
+              memory: 2Gi
             limits:
               cpu: 1000m
-              memory: 2Gi
+              memory: 2500Mi
           startupProbe:
             httpGet:
               path: /actuator/health

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -6,6 +6,11 @@ metadata:
     app: payment-service
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: payment-service
@@ -62,7 +67,7 @@ spec:
                   key: TOSS_CUSTOMER_KEY
           resources:
             requests:
-              cpu: 700m
+              cpu: 500m
               memory: 2Gi
             limits:
               cpu: 1000m

--- a/src/main/java/com/trustamarket/paymentservice/paymentservice/payout/infrastructure/pgNoop/PgNoOpClient.java
+++ b/src/main/java/com/trustamarket/paymentservice/paymentservice/payout/infrastructure/pgNoop/PgNoOpClient.java
@@ -1,0 +1,21 @@
+package com.trustamarket.paymentservice.paymentservice.payout.infrastructure.pgNoop;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import com.trustamarket.paymentservice.paymentservice.payout.application.port.out.pgClient.PgClientPort;
+import com.trustamarket.paymentservice.paymentservice.payout.application.port.out.pgClient.PgPayoutRequest;
+import com.trustamarket.paymentservice.paymentservice.payout.application.port.out.pgClient.PgPayoutResult;
+
+// K8s 프로필 임시 NoOp. PayoutEventHandler DI 만족용 — payout 엔드포인트 호출 시점에 명시적 fail.
+// 실 PG 클라이언트 도입 시 제거.
+@Component
+@Profile("k8s")
+public class PgNoOpClient implements PgClientPort {
+
+	@Override
+	public PgPayoutResult requestPayout(PgPayoutRequest request) {
+		throw new UnsupportedOperationException(
+			"payout not wired in k8s profile — PG client implementation pending");
+	}
+}


### PR DESCRIPTION
PayoutEventHandler 가 PgClientPort 를 DI 받는데 K8s 환경엔 구현체 없어서 부트 실패 (PgMockClient 는 mocktest 프로필 전용) 임시 NoOp — payout 엔드포인트 호출 시 UnsupportedOperationException.

실 PG 클라이언트 도입 시 제거.

## 🌱 설명

이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

-
-
-

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 결제 서비스 배포 전략 업데이트: 롤링 업데이트 시 배포 동작을 구체화했습니다.
  * 결제 서비스 메모리 리소스 조정: 요청 메모리는 1Gi에서 2Gi로, 제한 메모리는 2Gi에서 2500Mi로 변경되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/payment-service/pull/30)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->