### PR TITLE
datasource url DB_HOST env 추가 (Cloud SQL 마이그)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -49,6 +49,12 @@ spec:
                 secretKeyRef:
                   name: domain-postgres-secrets
                   key: DB_PASSWORD
+            # DB_HOST — Cloud SQL Private IP (Secret 에서 주입). application-k8s.yml 의 ${DB_HOST:postgres} 와 대응.
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_HOST
             # TOSS 결제 키 — Secret 'payment-secrets' 미리 생성 필요 (dummy 값 가능).
             - name: TOSS_SECRET_KEY
               valueFrom:

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -19,7 +19,8 @@ spring:
       label: develop
       fail-fast: false
   datasource:
-    url: jdbc:postgresql://postgres:5432/trusta_market
+    # DB_HOST env 로 endpoint 주입 (Secret domain-postgres-secrets). default = postgres (in-cluster fallback).
+    url: jdbc:postgresql://${DB_HOST:postgres}:5432/trusta_market
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     # HikariCP pool — default 10 이 thread 800 대비 너무 작아서 thread 가 pool 대기.


### PR DESCRIPTION
domain-postgres-secrets 의 DB_HOST 로 endpoint 주입. Cloud SQL Private IP 가 manifest/코드에 노출 X. default = postgres (in-cluster fallback).